### PR TITLE
Update gson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
         <gson-fire-version>1.8.5</gson-fire-version>
         <swagger-core-version>1.5.15</swagger-core-version>
         <okhttp-version>2.7.5</okhttp-version>
-        <gson-version>2.8.1</gson-version>
+        <gson-version>2.8.6</gson-version>
         <threetenbp-version>1.3.5</threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.1</junit-version>

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <gson-fire-version>1.8.0</gson-fire-version>
+        <gson-fire-version>1.8.5</gson-fire-version>
         <swagger-core-version>1.5.15</swagger-core-version>
         <okhttp-version>2.7.5</okhttp-version>
         <gson-version>2.8.1</gson-version>


### PR DESCRIPTION
In order to be able using this library as dependency in jenkins-gitea-plugin, both gson related dependencies need to be updated to the latest stable versions. This PR does this.

- Bump gson-version to 2.8.6
- Bump gson-fire to 1.8.5